### PR TITLE
[Feature] 메인페이지 UI 구성 

### DIFF
--- a/src/components/layout/Hero.tsx
+++ b/src/components/layout/Hero.tsx
@@ -1,0 +1,82 @@
+import { FeatureCheck } from "../common/Feature";
+import { StartButton } from "../common/Button";
+import { GradientText } from "../common/Text";
+import { NewBadge } from "../common/Badge";
+
+interface HeroTitleProps extends BaseProps {
+  children: React.ReactNode;
+}
+
+interface HeroSubtitleProps extends BaseProps {
+  children: React.ReactNode;
+}
+
+interface HeroDescriptionProps extends BaseProps {
+  children: React.ReactNode;
+}
+
+interface HeroActionsProps extends BaseProps {
+  buttonText: string;
+}
+
+interface HeroFeaturesProps extends BaseProps {
+  features: string[];
+}
+
+interface HeroContentProps extends BaseProps {
+  title: string;
+  subtitle: string;
+  description: string;
+  buttonText: string;
+  features: string[];
+}
+
+export const HeroTitle: React.FC<HeroTitleProps> = ({ children, className }) => (
+  <h1 className={`text-5xl lg:text-7xl font-bold tracking-tight ${className}`}>
+    <GradientText>{children}</GradientText>
+  </h1>
+);
+
+export const HeroSubtitle: React.FC<HeroSubtitleProps> = ({ children, className }) => (
+  <h2 className={`mt-4 text-3xl font-bold text-slate-900 ${className}`}>
+    {children}
+  </h2>
+);
+
+export const HeroDescription: React.FC<HeroDescriptionProps> = ({ children, className }) => (
+  <p className={`mt-6 text-lg text-slate-600 leading-relaxed ${className}`}>
+    {children}
+  </p>
+);
+
+export const HeroActions: React.FC<HeroActionsProps> = ({ buttonText, className }) => (
+  <div className={`mt-8 flex flex-col sm:flex-row items-start sm:items-center gap-4 ${className}`}>
+    <StartButton>{buttonText}</StartButton>
+  </div>
+);
+
+export const HeroFeatures: React.FC<HeroFeaturesProps> = ({ features, className }) => (
+  <div className={`mt-8 flex flex-col sm:flex-row items-start gap-6 ${className}`}>
+    {features.map((feature, index) => (
+      <FeatureCheck key={index} text={feature} />
+    ))}
+  </div>
+);
+
+export const HeroContent: React.FC<HeroContentProps> = ({ 
+  title,
+  subtitle,
+  description,
+  buttonText,
+  features,
+  className 
+}) => (
+  <div className={`relative z-10 max-w-2xl ${className}`}>
+    <NewBadge />
+    <HeroTitle>{title}</HeroTitle>
+    <HeroSubtitle>{subtitle}</HeroSubtitle>
+    <HeroDescription>{description}</HeroDescription>
+    <HeroActions buttonText={buttonText} />
+    <HeroFeatures features={features} />
+  </div>
+);

--- a/src/components/layout/Preview.tsx
+++ b/src/components/layout/Preview.tsx
@@ -1,0 +1,65 @@
+import { BlurredBackground } from "../common/Background";
+import { Card } from "../common/Card";
+
+interface EditorHeaderProps extends BaseProps {
+    filename?: string;
+  }
+
+  interface EditorLineProps extends BaseProps {
+    lineNumber: number;
+    width: string;
+  }
+
+  interface EditorContentProps extends BaseProps {
+    lines?: Array<{ lineNumber: number; width: string }>;
+  }
+  
+  export const EditorHeader: React.FC<EditorHeaderProps> = ({ filename = "main.py", className }) => (
+    <div className={`flex items-center justify-between mb-6 ${className}`}>
+      <div className="flex items-center space-x-2">
+        {['bg-rose-500', 'bg-amber-500', 'bg-emerald-500'].map((color, i) => (
+          <div key={i} className={`w-3 h-3 rounded-full ${color}`} />
+        ))}
+      </div>
+      <div className="px-3 py-1 bg-white/60 rounded-md text-xs text-slate-600 font-medium">
+        {filename}
+      </div>
+    </div>
+  );
+
+  
+  export const EditorLine: React.FC<EditorLineProps> = ({ lineNumber, width, className }) => (
+    <div className={`flex items-center space-x-3 ${className}`}>
+      <div className="w-8 text-right text-xs text-slate-400">{lineNumber}</div>
+      <div className={`${width} h-6 bg-gradient-to-r from-slate-200 to-slate-100 rounded-md`} />
+    </div>
+  );
+  
+  export const EditorContent: React.FC<EditorContentProps> = ({ 
+    lines = [
+      { lineNumber: 1, width: "w-3/4" },
+      { lineNumber: 2, width: "w-1/2" },
+      { lineNumber: 3, width: "w-2/3" },
+      { lineNumber: 4, width: "w-3/5" }
+    ],
+    className
+  }) => (
+    <div className={`space-y-3 ${className}`}>
+      {lines.map((line) => (
+        <EditorLine key={line.lineNumber} {...line} />
+      ))}
+    </div>
+  );
+  
+  export const IDEPreview: React.FC<BaseProps> = ({ className }) => (
+    <div className={`relative hidden lg:block ${className}`}>
+      <Card className="relative z-10 backdrop-blur-xl p-8 transform hover:-translate-y-2 hover:shadow-2xl">
+        <div className="h-[350px] bg-slate-50 rounded-xl p-6 overflow-hidden">
+          <EditorHeader />
+          <EditorContent />
+          <div className="mt-4 w-2 h-5 bg-[#354EAD] animate-pulse" />
+        </div>
+      </Card>
+      <BlurredBackground />
+    </div>
+  );

--- a/src/constants/feature.tsx
+++ b/src/constants/feature.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { Code2, Users, Zap } from 'lucide-react';
+
+export interface Feature {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+export const FEATURES: Feature[] = [
+  {
+    icon: <Code2 className="w-6 h-6" />,
+    title: "경량화된 IDE",
+    description: "최소한의 자원으로 모든 기기에서 실행되는 가벼운 개발 환경"
+  },
+  {
+    icon: <Users className="w-6 h-6" />,
+    title: "편리한 접근성",
+    description: "쉽게 이해하고 사용할 수 있는 직관적인 인터페이스"
+  },
+  {
+    icon: <Zap className="w-6 h-6" />,
+    title: "간편한 시작", 
+    description: "별도의 설치나 설정 없이 브라우저에서 바로 시작하는 코딩"
+  }
+];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,35 @@
-export default function Home() {
+import React from "react";
+import { HeroContent } from "@/components/layout/Hero";
+import { AnimatedBackground } from "@/components/common/Background";
+import { IDEPreview } from "@/components/layout/Preview";
+import { FeatureCard } from "@/components/common/Feature";
+import { FEATURES } from "@/constants/feature";
+
+const Home = () => {
   return (
-    <div>
-      <main>
-        <h1>Hello World</h1>
-      </main>
+    <div className="min-h-screen bg-slate-50 overflow-hidden relative">
+      <AnimatedBackground />
+
+      <section className="pt-20 lg:pt-24 pb-16">
+        <div className="container mx-auto px-6">
+          <div className="grid lg:grid-cols-2 gap-16 items-center">
+            <HeroContent title={"FLAKE IDE"} subtitle={"모두의 코딩 생활을 위해"} description={"디지털 정보 격차 해소를 위한 웹 기반의 교육용 IDE 플랫폼"} buttonText={"지금 시작하기"} features={['설치 불필요', '무료 체험 가능', '실시간 지원']} />
+            <IDEPreview />
+          </div>
+        </div>
+      </section>
+
+      <section id="features" className="py-16 bg-white/80">
+        <div className="container mx-auto px-6">
+          <div className="grid md:grid-cols-3 gap-8">
+            {FEATURES.map((feature, index) => (
+              <FeatureCard key={index} feature={feature} index={index} />
+            ))}
+          </div>
+        </div>
+      </section>
     </div>
   );
-}
+};
+
+export default Home;


### PR DESCRIPTION
## 📝 작업 내용
- [x] 메인페이지 임시 UI 초안 구현
- [x] layout 폴더 분리 후 Hero, Priview 컴포넌트 구현 

## ❄️  변경 사항
- **변경된 파일**:
  - `src/components/layout/Hero.tsx` - 메인페이지를 구성하는 Hero 영역 컴포넌트 
  - `src/components/layout/Preview.tsx` - 메인페이지 우측 Preview 이미지 컴포넌트
  - `src/components/constants/feature.tsx` - 메인페이지 소개 데이터
  - `src/types/common.ts` - 공통 type 정의
  - `src/pages/index.tsx` - 메인페이지 UI 적용

## 🔗 관련 이슈
#5 

## 📸 스크린샷 
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/de126ee7-1046-42a3-8f29-7454339a7777">

- 메인페이지 UI는 임시로 만들어두었습니다. 추후 변경시 수정 예정입니다. 


## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] UI/UX가 기대한 대로 작동합니다.

