### PR TITLE
[Feature] 선생님용 수업(Course) 목록 조회 대시보드 UI 퍼블리싱

### DIFF
--- a/src/components/sidebar/TeacherSidebar.tsx
+++ b/src/components/sidebar/TeacherSidebar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Sidebar } from './Sidebar';
+import { Book, Briefcase, PlusCircle, Settings } from 'lucide-react';
+
+export const TeacherSidebar: React.FC = () => {
+  const menuItems = [
+    { id: 'course', text: '내 수업', icon: Book },
+    { id: 'register', text: '수업 등록', icon: PlusCircle },
+    { id: 'work-list', text: '워크 / 트레이닝 목록', icon: Briefcase },
+    { id: 'setting', text: '프로필', icon: Settings },
+  ];
+
+  return (
+    <Sidebar
+      profile={{
+        name: '선생님 이름',
+        avatar: {
+          src: 'https://via.placeholder.com/150',
+          alt: '선생님 프로필 이미지',
+        },
+        subtitle: '환영합니다',
+      }}
+      menuItems={menuItems}
+      onMenuItemClick={(id) => console.log(`Teacher clicked ${id}`)}
+    />
+  );
+};

--- a/src/pages/teacher/courses/index.tsx
+++ b/src/pages/teacher/courses/index.tsx
@@ -1,0 +1,59 @@
+import { AddCard } from '@/components/common/Card/AddCard';
+import { CourseCard } from '@/components/common/Card/CourseCard';
+import SearchInput from '@/components/common/Search/Search';
+import { PageHeader } from '@/components/layout/PageHeader/PageHeader';
+import { TeacherSidebar } from '@/components/sidebar/TeacherSidebar';
+import { useState } from 'react';
+import { FiSearch } from 'react-icons/fi';
+
+const CourseDashboard: React.FC = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50/50">
+      <TeacherSidebar />
+
+      <div className="ml-72 p-8">
+        <PageHeader
+          pageTitle="MY COURSE"
+          role="teacher"
+          hasBackButton
+          hasSubtitle
+          subtitle="전체 수업 목록을 확인해보세요"
+        />
+
+        <div className="my-8">
+          <SearchInput
+            placeholder="수업 검색하기"
+            value={searchTerm}
+            onChange={handleSearchChange}
+            icon={FiSearch}
+            iconClassName="text-gray-400"
+            inputClassName="text-gray-800"
+          />
+        </div>
+
+        <div className="grid grid-cols-4 gap-5">
+          <CourseCard
+            title="모두 함께 파이썬"
+            description="기초부터 시작하는 파이썬 프로그래밍"
+            students="45"
+            isNew
+          />
+          <CourseCard
+            title="공부를 해볼까요?"
+            description="새로운 강의를 시작해보세요"
+            students="23"
+          />
+          <AddCard />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CourseDashboard;


### PR DESCRIPTION
## 📝 작업 내용
선생님용 수업(Course) 목록 조회 대시보드 UI 퍼블리싱

- [x] 선생님용 TeacherSidebar 컴포넌트 구현
- [x] 선생님용 Course 목록 페이지 UI 퍼블리싱


## ❄️  변경 사항
변경된 주요 파일과 컴포넌트를 간단히 정리해주세요
- **변경된 파일**:
  - `src/components/sidebar/TeacherSidebar.tsx` : 선생님용 사이드바 컨테이너 분리 
  - `src/pages/teacher/courses/index.tsx` : 선생님용 Course 목록 페이지 UI 퍼블리싱 


## 🔗 관련 이슈
close #32 



## 📸 스크린샷 
![image](https://github.com/user-attachments/assets/9c431f81-8460-4305-b976-74df7fdc4d5b)



## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] UI/UX가 기대한 대로 작동합니다.

