### PR TITLE
[Feature] CodeInput 컴포넌트 구현 및 CourseRegister 페이지 퍼블리싱

### DIFF
--- a/src/components/common/Input/CodeInput.stories.tsx
+++ b/src/components/common/Input/CodeInput.stories.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import CodeInput, { CodeInputProps } from './CodeInput';
+
+export default {
+  title: 'Components/CodeInput',
+  component: CodeInput,
+  argTypes: {
+    length: {
+      control: { type: 'number' },
+      defaultValue: 6,
+      description: 'Number of input fields',
+    },
+    onChange: {
+      action: 'changed',
+      description: 'Callback function triggered when code changes',
+    },
+  },
+} as Meta<typeof CodeInput>;
+
+const Template: StoryFn<CodeInputProps> = (args) => {
+  const [code, setCode] = useState('');
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '400px', margin: 'auto' }}>
+      <h1 style={{ fontSize: '18px', marginBottom: '10px' }}>Code Input Example</h1>
+      <CodeInput {...args} onChange={(value) => setCode(value)} />
+      <p style={{ marginTop: '20px', color: 'gray' }}>
+        입력된 코드: <strong>{code}</strong>
+      </p>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  length: 6,
+};
+
+export const FourDigitCode = Template.bind({});
+FourDigitCode.args = {
+  length: 4,
+};

--- a/src/components/common/Input/CodeInput.tsx
+++ b/src/components/common/Input/CodeInput.tsx
@@ -45,7 +45,7 @@ const CodeInput: React.FC<CodeInputProps> = ({
           ref={(el) => {
             inputRefs.current[index] = el;
           }}
-          className="w-12 h-12 text-center text-lg font-bold bg-gray-50 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none focus:ring"
+          className="w-24 h-24 text-center text-lg font-bold bg-gray-50 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none focus:ring"
           maxLength={1}
           value={digit}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/common/Input/CodeInput.tsx
+++ b/src/components/common/Input/CodeInput.tsx
@@ -1,20 +1,25 @@
 import React, { useState, useRef, ChangeEvent, KeyboardEvent } from 'react';
 
 export interface CodeInputProps {
-  length?: number; 
+  length?: number;
   onChange: (code: string) => void; 
+  layout?: 'horizontal' | 'vertical'; 
 }
 
-const CodeInput: React.FC<CodeInputProps> = ({ length = 6, onChange }) => {
+const CodeInput: React.FC<CodeInputProps> = ({
+  length = 6,
+  onChange,
+  layout = 'horizontal', 
+}) => {
   const [code, setCode] = useState<string[]>(Array(length).fill(''));
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   const handleInput = (index: number, value: string) => {
     if (value.length <= 1) {
       const newCode = [...code];
-      newCode[index] = value.toUpperCase(); 
+      newCode[index] = value.toUpperCase();
       setCode(newCode);
-      onChange(newCode.join('')); 
+      onChange(newCode.join(''));
 
       if (value && index < length - 1) {
         inputRefs.current[index + 1]?.focus();
@@ -29,17 +34,18 @@ const CodeInput: React.FC<CodeInputProps> = ({ length = 6, onChange }) => {
   };
 
   return (
-    <div className={`grid grid-cols-${length} gap-3 sm:gap-4 md:gap-6`}>
+    <div
+      className={`${
+        layout === 'horizontal' ? 'flex gap-4 justify-center' : 'grid gap-3 grid-cols-1'
+      }`}
+    >
       {code.map((digit, index) => (
         <input
           key={index}
           ref={(el) => {
-            inputRefs.current[index] = el; 
+            inputRefs.current[index] = el;
           }}
-          className="aspect-square w-full text-center text-3xl sm:text-4xl md:text-5xl font-bold 
-            bg-gray-50/50 border-2 border-gray-200 rounded-xl
-            focus:border-blue-500 focus:ring-4 focus:ring-blue-500/20 
-            outline-none uppercase transition-all"
+          className="w-12 h-12 text-center text-lg font-bold bg-gray-50 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none focus:ring"
           maxLength={1}
           value={digit}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/common/Input/CodeInput.tsx
+++ b/src/components/common/Input/CodeInput.tsx
@@ -45,7 +45,7 @@ const CodeInput: React.FC<CodeInputProps> = ({
           ref={(el) => {
             inputRefs.current[index] = el;
           }}
-          className="w-24 h-24 text-center text-lg font-bold bg-gray-50 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none focus:ring"
+          className="w-24 h-24 text-center text-4xl font-bold bg-gray-50 border border-gray-300 rounded-md focus:border-blue-500 focus:outline-none focus:ring"
           maxLength={1}
           value={digit}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/common/Input/CodeInput.tsx
+++ b/src/components/common/Input/CodeInput.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef, ChangeEvent, KeyboardEvent } from 'react';
+
+export interface CodeInputProps {
+  length?: number; 
+  onChange: (code: string) => void; 
+}
+
+const CodeInput: React.FC<CodeInputProps> = ({ length = 6, onChange }) => {
+  const [code, setCode] = useState<string[]>(Array(length).fill(''));
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const handleInput = (index: number, value: string) => {
+    if (value.length <= 1) {
+      const newCode = [...code];
+      newCode[index] = value.toUpperCase(); 
+      setCode(newCode);
+      onChange(newCode.join('')); 
+
+      if (value && index < length - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+    }
+  };
+
+  const handleKeyDown = (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && !code[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  return (
+    <div className={`grid grid-cols-${length} gap-3 sm:gap-4 md:gap-6`}>
+      {code.map((digit, index) => (
+        <input
+          key={index}
+          ref={(el) => {
+            inputRefs.current[index] = el; 
+          }}
+          className="aspect-square w-full text-center text-3xl sm:text-4xl md:text-5xl font-bold 
+            bg-gray-50/50 border-2 border-gray-200 rounded-xl
+            focus:border-blue-500 focus:ring-4 focus:ring-blue-500/20 
+            outline-none uppercase transition-all"
+          maxLength={1}
+          value={digit}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            handleInput(index, e.target.value)
+          }
+          onKeyDown={(e: KeyboardEvent<HTMLInputElement>) =>
+            handleKeyDown(index, e)
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CodeInput;

--- a/src/pages/student/courses/register.tsx
+++ b/src/pages/student/courses/register.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/common/Button/Button";
+import { StartButton } from "@/components/common/Button/StartButton";
+import { Card } from "@/components/common/Card/Card";
+import CodeInput from "@/components/common/Input/CodeInput";
+import { PageHeader } from "@/components/layout/PageHeader/PageHeader";
+import { StudentSidebar } from "@/components/sidebar/StudentSidebar";
+import { useState } from "react";
+
+const CourseRegister: React.FC = () => {
+  const [code, setCode] = useState("");
+
+  return (
+    <div className="min-h-screen bg-gray-50/50">
+      <StudentSidebar />
+      <div className="ml-72 p-8">
+        <PageHeader
+          pageTitle="COURSE 등록하기"
+          role="student"
+          status="in-progress"
+        />
+        <Card className="p-16 m-36 flex flex-col items-center">
+          <h2 className="text-3xl font-bold text-gray-800 mb-6">수업 코드 입력</h2>
+          <p className="text-lg text-gray-800 mb-8">
+            선생님으로부터 받은 6자리 코드를 입력해주세요
+          </p>
+          <div className="mb-8">
+            <CodeInput
+              length={6}
+              onChange={(value) => setCode(value)}
+            />
+          </div>
+          <StartButton hasIcon={false}>등록하기</StartButton>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default CourseRegister;


### PR DESCRIPTION
## 📝 작업 내용
초대 코드를 통해 새로운 수업을 등록할 수 있는 학생(눈송이)용 수업등록 페이지 UI 퍼블리싱

- CodeInput 컴포넌트 구현
  - 6자리 초대코드를 입력할 수 있는 숫자 입력 컴포넌트 설계
  - `horizontal` 또는 `vertical`을 선택해 입력 필드 배치 방향을 설정 가능
  - 입력 필드 크기 조정
  - Storybook 테스트를 위한 Story 구현
- CourseRegister 페이지 UI 퍼블리싱
  - `CodeInput` 컴포넌트를 활용하여 6자리 초대 코드를 입력할 수 있도록 구성
  - Card 컴포넌트 안에 사용자 안내 텍스트 및 입력 필드 배치


## ❄️  변경 사항
- **변경된 파일**:
  - src/components/common/input/CodeInput.tsx
  - src/components/common/input/CodeInput.stories.tsx
  - src/pages/student/courses/register.tsx

## 🔗 관련 이슈
#31 

## 📸 스크린샷
<img width="1459" alt="image" src="https://github.com/user-attachments/assets/59e0889d-9da5-406f-aa18-5af2d48b26f0">

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] UI/UX가 기대한 대로 작동합니다.

