### PR TITLE
[Feature] 선생님용 수업(Course) 등록 완료 페이지 구성요소 컴포넌트 구현 및 페이지 퍼블리싱

### DIFF
--- a/src/components/common/Box/CodeBox.stories.tsx
+++ b/src/components/common/Box/CodeBox.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { CodeBox } from '@/components/common/Box/CodeBox';
+
+const meta: Meta<typeof CodeBox> = {
+  title: 'Components/Box/Code Box',
+  component: CodeBox,
+  tags: ['autodocs'],
+  argTypes: {
+    code: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Template: StoryFn<typeof CodeBox> = (args) => <CodeBox {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  code: '14SE2W',
+};

--- a/src/components/common/Box/CodeBox.tsx
+++ b/src/components/common/Box/CodeBox.tsx
@@ -4,9 +4,9 @@ interface CodeBoxProps extends BaseProps {
 
 export const CodeBox = ({ code }: CodeBoxProps) => {
   return (
-    <div className="max-w-[80%] px-10 py-5 rounded-lg flex flex-row bg-gray-50 border gap-10 border-slate-200 justify-center items-center">
+    <div className="px-32 py-5 rounded-lg flex flex-row bg-gray-50 border gap-10 border-slate-200 justify-center items-center">
       {code.split('').map((char, idx) => (
-        <span className="text-4xl font-bold">{char}</span>
+        <span className="text-6xl font-bold">{char}</span>
       ))}
     </div>
   );

--- a/src/components/common/Box/CodeBox.tsx
+++ b/src/components/common/Box/CodeBox.tsx
@@ -1,0 +1,13 @@
+interface CodeBoxProps extends BaseProps {
+  code: string;
+}
+
+export const CodeBox = ({ code }: CodeBoxProps) => {
+  return (
+    <div className="max-w-[80%] px-10 py-5 rounded-lg flex flex-row bg-gray-50 border gap-10 border-slate-200 justify-center items-center">
+      {code.split('').map((char, idx) => (
+        <span className="text-4xl font-bold">{char}</span>
+      ))}
+    </div>
+  );
+};

--- a/src/components/common/Button/CopyButton.stories.tsx
+++ b/src/components/common/Button/CopyButton.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { CopyButton } from '@/components/common/Button/CopyButton';
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Components/Button/Copy Button',
+  component: CopyButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Template: StoryFn<typeof CopyButton> = (args) => <CopyButton />;
+
+export const Default = Template.bind({});

--- a/src/components/common/Button/CopyButton.tsx
+++ b/src/components/common/Button/CopyButton.tsx
@@ -1,0 +1,27 @@
+import { Button, ButtonProps } from '@/components/common/Button/Button';
+import { Copy } from 'lucide-react';
+
+export const CopyButton: React.FC<ButtonProps> = ({ children, ...props }) => {
+  const handleCopy = () => {
+    const copyCode = document.getElementById('copyTxt');
+
+    if (
+      copyCode instanceof HTMLInputElement ||
+      copyCode instanceof HTMLTextAreaElement
+    ) {
+      copyCode.select();
+      navigator.clipboard.writeText(copyCode.value);
+      alert('복사되었습니다!');
+    }
+  };
+
+  return (
+    <Button
+      className="flex items-center px-6 py-4 text-lg gap-x-3 font-medium text-blue-50 bg-blue-800 rounded-lg cursor-pointer"
+      onClick={handleCopy}
+    >
+      <Copy className="w-6 h-6 text-blue-50" />
+      코드 복사하기
+    </Button>
+  );
+};

--- a/src/components/common/Button/CopyButton.tsx
+++ b/src/components/common/Button/CopyButton.tsx
@@ -17,7 +17,7 @@ export const CopyButton: React.FC<ButtonProps> = ({ children, ...props }) => {
 
   return (
     <Button
-      className="flex items-center px-6 py-4 text-lg gap-x-3 font-medium text-blue-50 bg-blue-800 rounded-lg cursor-pointer"
+      className="flex items-center px-5 py-3 text-lg gap-x-3 font-medium text-blue-50 bg-blue-800 rounded-lg cursor-pointer"
       onClick={handleCopy}
     >
       <Copy className="w-6 h-6 text-blue-50" />

--- a/src/components/common/Button/InviteButton.stories.tsx
+++ b/src/components/common/Button/InviteButton.stories.tsx
@@ -6,11 +6,22 @@ const meta: Meta<typeof InviteButton> = {
   title: 'Components/Button/Invite Button',
   component: InviteButton,
   tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['medium', 'large'],
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const Template: StoryFn<typeof InviteButton> = (args) => <InviteButton />;
+const Template: StoryFn<typeof InviteButton> = (args) => (
+  <InviteButton {...args} />
+);
 
 export const Default = Template.bind({});
+Default.args = {
+  size: 'medium',
+};

--- a/src/components/common/Button/InviteButton.tsx
+++ b/src/components/common/Button/InviteButton.tsx
@@ -1,9 +1,17 @@
-import { Button } from '@/components/common/Button/Button';
+import { Button, ButtonProps } from '@/components/common/Button/Button';
 import { Share2 } from 'lucide-react';
 
-export const InviteButton = () => (
-  <Button className="flex items-center px-4 py-2 gap-x-3 bg-blue-50 text-blue-800 rounded-lg cursor-pointer">
+interface InviteButtonProps extends BaseProps {
+  size?: 'medium' | 'large';
+}
+
+export const InviteButton = ({ size = 'medium' }: InviteButtonProps) => (
+  <Button
+    className={`flex items-center gap-x-3 bg-blue-50 text-blue-800 rounded-lg cursor-pointer ${
+      size === 'medium' ? 'px-4 py-2' : 'px-6 py-4 text-lg font-medium'
+    }`}
+  >
     <Share2 className="w-4 h-4 text-blue-800" />
-    초대하기
+    {size === 'medium' ? '초대하기' : '공유하기'}
   </Button>
 );

--- a/src/components/common/Button/InviteButton.tsx
+++ b/src/components/common/Button/InviteButton.tsx
@@ -8,7 +8,7 @@ interface InviteButtonProps extends BaseProps {
 export const InviteButton = ({ size = 'medium' }: InviteButtonProps) => (
   <Button
     className={`flex items-center gap-x-3 bg-blue-50 text-blue-800 rounded-lg cursor-pointer ${
-      size === 'medium' ? 'px-4 py-2' : 'px-6 py-4 text-lg font-medium'
+      size === 'medium' ? 'px-4 py-2' : 'px-5 py-3 text-lg font-medium'
     }`}
   >
     <Share2 className="w-4 h-4 text-blue-800" />

--- a/src/pages/teacher/courses/create/complete.tsx
+++ b/src/pages/teacher/courses/create/complete.tsx
@@ -1,0 +1,51 @@
+import { CodeBox } from '@/components/common/Box/CodeBox';
+import { CopyButton } from '@/components/common/Button/CopyButton';
+import { InviteButton } from '@/components/common/Button/InviteButton';
+import { Card } from '@/components/common/Card/Card';
+import { PreviewCard } from '@/components/common/Card/PreviewCard';
+import { CourseForm } from '@/components/layout/CourseForm/CourseForm';
+import { PageHeader } from '@/components/layout/PageHeader/PageHeader';
+import { TeacherSidebar } from '@/components/sidebar/TeacherSidebar';
+
+const CoureseCreattionComplete: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50/50">
+      <TeacherSidebar />
+
+      <div className="ml-72 p-8">
+        <PageHeader
+          pageTitle="Course 등록하기"
+          role="teacher"
+          hasBackButton
+          hasSubtitle={false}
+        />
+
+        <Card className="p-16 m-36 flex flex-col items-center">
+          <h2 className="text-3xl font-bold text-gray-800 mb-3">초대 코드</h2>
+          <p className="text-lg text-gray-600 mb-4">
+            학생들과 공유할 수업 코드입니다.
+          </p>
+          <div className="my-8">
+            <CodeBox code="12GW2S" />
+          </div>
+          <div className="flex flex-col justify-center items-center mb-8">
+            <h3 className="font-extrabold text-blue-800 text-2xl mb-3">
+              모두 함께 파이썬
+            </h3>
+            <p className="font-medium text-base">수업이 등록되었습니다.</p>
+            <p className="font-medium text-base">
+              초대 코드를 복사하여 학생들에게 공유해주세요!
+            </p>
+          </div>
+
+          <div className="flex flex-row space-x-4 justify-center items-center">
+            <CopyButton />
+            <InviteButton size="large" />
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default CoureseCreattionComplete;


### PR DESCRIPTION
## 📝 작업 내용
선생님용 수업(Course) 등록 완료 페이지 구성요소 컴포넌트 구현 및 페이지 퍼블리싱
- [x] 수업 등록 완료 페이지 퍼블리싱
- [x] 구성 요소 컴포넌트 및 스토리북 구현
  - [x] `CopyButton` 
  - [x] `InviteButton` : 사이즈 props를 통해 크기 및 멘트 조정
  - [x] `CodeBox`


## ❄️  변경 사항
변경된 주요 파일과 컴포넌트를 간단히 정리해주세요
- **변경된 파일**:
   - `src/components/common/Box/CopyBox`
   - `src/components/common/Button/InviteButton`
   - `src/components/common/Button/CopyButton`
   -  `src/pages/teacher/course/create/complete`



## 🔗 관련 이슈
close #37 



## 📸 스크린샷 
![image](https://github.com/user-attachments/assets/4e57db27-e56e-412c-88df-6a8be50ef0c2)



## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] UI/UX가 기대한 대로 작동합니다.
