### PR TITLE
[Fix] InviteButton 컴포넌트의 Storybook 타입 에러 수정

### DIFF
--- a/src/components/common/Button/InviteButton.tsx
+++ b/src/components/common/Button/InviteButton.tsx
@@ -5,6 +5,7 @@ interface InviteButtonProps extends BaseProps {
   className?: string;
   label: string;
   icon: LucideIcon;
+  size?: 'medium' | 'large';
 }
 
 export const InviteButton = ({


### PR DESCRIPTION
## 📝 작업 내용
- [x]  InviteButton 컴포넌트의 Props 타입에 size 속성 추가
- [x]  Storybook ArgTypes 타입 에러 해결

## 🔗 관련 이슈
Fixes #53 

## 🏃 테스트 방법
- npm run storybook 실행하여 InviteButton 컴포넌트 확인
- size 옵션 변경하며 동작 확인
- npm run build 실행하여 타입 에러 해결 확인

## ✅ 체크리스트
- [x] 타입 에러 해결
- [x]  빌드 성공 확인
- [x]  스토리북에서 정상 동작 확인
- [x]  기존 기능에 영향 없음 확인
