### PR TITLE
[style] Pretendard 웹폰트 적용

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,12 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+       <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+        />
+      </Head>
       <body className="antialiased">
         <Main />
         <NextScript />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -15,7 +15,8 @@
 }
 
 body {
+  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## 📝 작업 내용
Pretendard 웹폰트를 프로젝트에 추가하고, 글로벌 스타일에 반영 

**세부 작업**
- Pretendard 웹폰트 CDN 추가
- `_document.tsx`에 `<link>` 태그 삽입하여 적용
-  `globals.css`에 기본 폰트 설정
- 로컬 환경 및 배포 환경에서 폰트 적용 확인