### PR TITLE
[Design] StudentSidebar 색상 변경

### DIFF
--- a/src/components/common/Badge/RoleBadge.tsx
+++ b/src/components/common/Badge/RoleBadge.tsx
@@ -1,9 +1,13 @@
 interface RoleBadgeProps extends BaseProps {
-  role: string;
+  role: '눈솔' | '눈송이';
 }
 
 export const RoleBadge = ({ role }: RoleBadgeProps) => (
-  <div className="inline-block px-3 py-2 bg-blue-800 text-white rounded-lg font-medium text-sm">
+  <div
+    className={`inline-block px-3 py-2 ${
+      role === '눈솔' ? 'bg-blue-800' : 'bg-student-primary'
+    }  text-white rounded-lg font-medium text-sm`}
+  >
     {role}
   </div>
 );

--- a/src/components/common/Button/PracticeButton.tsx
+++ b/src/components/common/Button/PracticeButton.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 import { Code2, ChevronRight } from 'lucide-react';
 
 export interface PracticeButtonProps {
+  isStudent?: boolean;
   url: string;
 }
 
-const PracticeButton: React.FC<PracticeButtonProps> = ({ url }) => {
+const PracticeButton: React.FC<PracticeButtonProps> = ({ isStudent, url }) => {
   return (
     <div className="mb-8 overflow-hidden">
-      <div className="bg-gradient-to-r from-blue-800 to-blue-500 p-6 rounded-xl">
+      <div
+        className={`bg-gradient-to-r ${
+          isStudent
+            ? 'from-student-secondary to-student-primary'
+            : 'from-blue-800 to-blue-500'
+        } p-6 rounded-xl`}
+      >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
             <div className="p-3 bg-white/10 rounded-xl">

--- a/src/components/common/Card/AddCard.tsx
+++ b/src/components/common/Card/AddCard.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { BaseCard } from './BaseCard';
 
 export const AddCard: React.FC<AddCardProps> = ({
+  isStudent = false,
   icon: Icon = Plus,
   text = '새 수업 추가하기',
   onClick,
@@ -14,9 +15,18 @@ export const AddCard: React.FC<AddCardProps> = ({
     <BaseCard
       variant="dashed"
       onClick={onClick}
-      className={cn("flex items-center justify-center h-[267px] group", className)}
+      className={cn(
+        'flex items-center justify-center h-[267px] group',
+        className,
+      )}
     >
-      <div className="flex flex-col items-center text-gray-400 group-hover:text-blue-800">
+      <div
+        className={`flex flex-col items-center text-gray-400 ${
+          isStudent
+            ? 'group-hover:text-student-secondary'
+            : 'group-hover:text-blue-800'
+        }`}
+      >
         <Icon className="w-10 h-10 mb-2" />
         <span className="text-xs font-medium">{text}</span>
       </div>

--- a/src/components/common/Card/CourseCard.tsx
+++ b/src/components/common/Card/CourseCard.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { BaseCard } from './BaseCard';
 
 export const CourseCard: React.FC<CourseCardProps> = ({
+  isStudent = false,
   title,
   description,
   students,
@@ -13,15 +14,28 @@ export const CourseCard: React.FC<CourseCardProps> = ({
   className,
 }) => {
   return (
-    <BaseCard className={cn("group overflow-hidden", className)} onClick={onClick}>
-      <div className="h-36 bg-gradient-to-br from-blue-800 to-blue-500 relative overflow-hidden">
+    <BaseCard
+      className={cn('group overflow-hidden', className)}
+      onClick={onClick}
+    >
+      <div
+        className={`h-36 bg-gradient-to-br ${
+          isStudent
+            ? 'from-student-secondary to-student-primary'
+            : 'from-blue-800 to-blue-500'
+        } relative overflow-hidden`}
+      >
         <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
         <div className="absolute top-3 right-3 bg-white/10 backdrop-blur-md rounded-full px-2.5 py-0.5 text-white text-xs flex items-center gap-1.5">
           <Users size={12} />
           {students}
         </div>
         {isNew && (
-          <div className="absolute top-3 left-3 bg-blue-500 text-white text-xs font-medium px-2 py-0.5 rounded-full">
+          <div
+            className={`absolute top-3 left-3 ${
+              isStudent ? 'bg-student-primary/50' : 'bg-blue-500'
+            } text-white text-xs font-medium px-2 py-0.5 rounded-full`}
+          >
             NEW
           </div>
         )}

--- a/src/components/sidebar/MenuItemButton.tsx
+++ b/src/components/sidebar/MenuItemButton.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { MenuItemButtonProps } from '@/types/sidebar';
 import { SidebarIcon } from './SidebarIcon';
 
-export const MenuItemButton: React.FC<MenuItemButtonProps> = ({ 
+export const MenuItemButton: React.FC<MenuItemButtonProps> = ({
+  isStudent,
   icon,
   children,
   active = false,
   onClick,
-  className = ''
+  className = '',
 }) => {
   return (
     <button
@@ -15,7 +16,19 @@ export const MenuItemButton: React.FC<MenuItemButtonProps> = ({
       className={`
         w-full flex items-center gap-3 px-4 py-3 rounded-lg
         transition-all
-        ${active ? 'bg-blue-800 text-white' : 'text-white hover:bg-blue-800'}
+        ${
+          active
+            ? `${
+                isStudent
+                  ? 'bg-student-secondary/70 text-white'
+                  : 'bg-blue-800 text-white'
+              } `
+            : `${
+                isStudent
+                  ? 'hover:bg-student-secondary/70 text-white'
+                  : 'hover:bg-blue-800 text-white'
+              }`
+        }
         ${className}
       `}
     >

--- a/src/components/sidebar/Navigation.tsx
+++ b/src/components/sidebar/Navigation.tsx
@@ -4,6 +4,7 @@ import { MenuItemButton } from './MenuItemButton';
 import { useRouter } from 'next/router';
 
 export const Navigation: React.FC<NavigationProps> = ({
+  isStudent,
   items = [],
   activeItem,
   setActiveItem,
@@ -15,6 +16,7 @@ export const Navigation: React.FC<NavigationProps> = ({
     <nav className={`space-y-2 ${className}`}>
       {items.map((item) => (
         <MenuItemButton
+          isStudent={isStudent as boolean}
           key={item.id}
           icon={item.icon}
           active={activeItem === item.id}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import { ProfileSection } from './ProfileSection';
 import { Navigation } from './Navigation';
 
 export const Sidebar: React.FC<SidebarProps> = ({
+  role,
   profile,
   menuItems,
   activeItem,
@@ -13,11 +14,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   return (
     <aside
-      className={`fixed left-0 top-0 h-screen w-72 bg-blue-700 p-6 ${className}`}
+      className={`fixed left-0 top-0 h-screen w-72 ${
+        role === 'student' ? 'bg-student-primary' : 'bg-blue-700'
+      } p-6 ${className}`}
     >
       {profile && <ProfileSection {...profile} className="mb-10" />}
 
       <Navigation
+        isStudent={role === 'student'}
         items={menuItems}
         activeItem={activeItem}
         setActiveItem={setActiveItem}

--- a/src/components/sidebar/StudentSidebar.tsx
+++ b/src/components/sidebar/StudentSidebar.tsx
@@ -16,6 +16,7 @@ export const StudentSidebar: React.FC = () => {
 
   return (
     <Sidebar
+      role="student"
       profile={{
         name: '학생 이름',
         avatar: {

--- a/src/components/sidebar/TeacherSidebar.tsx
+++ b/src/components/sidebar/TeacherSidebar.tsx
@@ -39,6 +39,7 @@ export const TeacherSidebar: React.FC = () => {
 
   return (
     <Sidebar
+      role="teacher"
       profile={{
         name: '선생님 이름',
         avatar: {

--- a/src/pages/student/courses/[courseId]/index.tsx
+++ b/src/pages/student/courses/[courseId]/index.tsx
@@ -10,33 +10,35 @@ import { sortWorks } from '@/lib/sortWorks';
 import { worksData } from '@/data/worksData';
 
 const CourseDetail = () => {
-  const [sortType, setSortType] = useState<'deadline' | 'submission'>('deadline');
+  const [sortType, setSortType] = useState<'deadline' | 'submission'>(
+    'deadline',
+  );
   const sortedWorks = sortWorks(worksData, sortType);
 
   return (
     <>
-        <PageHeader
-          pageTitle="모두 함께 파이썬"
-          role="student"
-          hasBackButton
-          hasSubtitle
-          subtitle="기초부터 시작하는 파이썬 프로그래밍"
-          status="in-progress"
-        />
-        <div className="my-8">
-          <div className="grid grid-cols-3 gap-6 mb-8">
-            <StatCard label="총 워크" value="6개" icon={Book} />
-            <StatCard label="제출한 워크" value="1개" icon={CheckCircleIcon} />
-            <StatCard label="남은 워크" value="5개" icon={Clock} />
-          </div>
+      <PageHeader
+        pageTitle="모두 함께 파이썬"
+        role="student"
+        hasBackButton
+        hasSubtitle
+        subtitle="기초부터 시작하는 파이썬 프로그래밍"
+        status="in-progress"
+      />
+      <div className="my-8">
+        <div className="grid grid-cols-3 gap-6 mb-8">
+          <StatCard label="총 워크" value="6개" icon={Book} />
+          <StatCard label="제출한 워크" value="1개" icon={CheckCircleIcon} />
+          <StatCard label="남은 워크" value="5개" icon={Clock} />
         </div>
-        <PracticeButton url="#" />
-        <Card>
-          {sortedWorks.map((work) => (
-            <WorkItem key={work.id} {...work} />
-          ))}
-        </Card>
-      </>
+      </div>
+      <PracticeButton url="#" isStudent />
+      <Card>
+        {sortedWorks.map((work) => (
+          <WorkItem key={work.id} {...work} />
+        ))}
+      </Card>
+    </>
   );
 };
 

--- a/src/pages/student/courses/index.tsx
+++ b/src/pages/student/courses/index.tsx
@@ -34,17 +34,19 @@ const CourseDashboard: React.FC = () => {
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-5">
         <CourseCard
+          isStudent
           title="모두 함께 파이썬"
           description="기초부터 시작하는 파이썬 프로그래밍"
           students="45"
           isNew
         />
         <CourseCard
+          isStudent
           title="공부를 해볼까요?"
           description="새로운 강의를 시작해보세요"
           students="23"
         />
-        <AddCard />
+        <AddCard isStudent />
       </div>
     </>
   );

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -11,6 +11,7 @@ export interface BaseCardProps {
 }
 
 export interface CourseCardProps {
+  isStudent?: boolean;
   title: string;
   description: string;
   students: string | number;
@@ -20,6 +21,7 @@ export interface CourseCardProps {
 }
 
 export interface AddCardProps {
+  isStudent?: boolean;
   icon?: LucideIcon;
   text?: string;
   onClick?: () => void;

--- a/src/types/sidebar.ts
+++ b/src/types/sidebar.ts
@@ -40,6 +40,7 @@ export interface SidebarIconProps {
 }
 
 export interface MenuItemButtonProps {
+  isStudent: boolean;
   icon: LucideIcon;
   children: React.ReactNode;
   active?: boolean;
@@ -63,6 +64,7 @@ export interface ProfileSectionProps extends ProfileConfig {
 }
 
 export interface NavigationProps {
+  isStudent?: boolean;
   items: MenuItem[];
   activeItem?: string;  
   setActiveItem: (value: string) => void;
@@ -72,6 +74,7 @@ export interface NavigationProps {
 
 export interface SidebarProps {
   profile?: ProfileConfig;
+  role: 'teacher' | 'student';
   menuItems: MenuItem[];
   activeItem?: string;
   setActiveItem: (value: string) => void;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        'student-primary': '#8EBBF7',
+        'student-secondary': '#148CCC',
         custom: {
           lightest: "#FFF9EF", 
           light: "#ECF0F4", 


### PR DESCRIPTION
## 📝 작업 내용
선생님 페이지와의 Sidebar 색상에 차별점을 두어 전환하는데 있어 임팩트를 주는게 좋을거같습니다.
- [x] 학생 대표 색상 두가지 정의
- [x] 학생 및 선생님 공통 사용하는 컴포넌트 색상 차별화


## ❄️  변경 사항
- 선생님과 학생이 공유하는 컴포넌트의 props로 `isStudent`라는 `boolean`값을 받아와 차별화를 주었습니다.
- 학생 대표 색상은 `student-primary`, `student-secondary/70` 을 사용하였습니다.



## 🔗 관련 이슈
close #60 



## 📸 스크린샷 
![localhost_3000_student_courses_1 (3)](https://github.com/user-attachments/assets/e8f61fc2-054b-47dd-955f-6d608384938c)
![localhost_3000_student_courses (4)](https://github.com/user-attachments/assets/083e8e76-c7c5-42d3-95f2-8835ab58c855)


## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] UI/UX가 기대한 대로 작동합니다.
